### PR TITLE
Добавление результата сборки к релизам

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -27,7 +27,8 @@ jobs:
                     make RESULT_PDF='${{ env.RESULT_PDF }}'
             - name: Release
               run: |
-                gh release create ${{ github.ref_name}} -t '${{ env.NAME }}' '${{ env.RESULT_PDF }}'#'${{ env.ASSET_LABEL }}'
+                gh release create ${{ github.ref_name}} -t '${{ env.NAME }}' '${{ env.RESULT_PDF }}'#'${{ env.ASSET_LABEL }}' \
+                    || gh release upload --clobber ${{ github.ref_name}} '${{ env.RESULT_PDF }}'#'${{ env.ASSET_LABEL }}'
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 NAME: 'Перевод курса "RISC-V Toolchain and Compiler Optimization Techniques" (LFD113x) ${{ github.ref_name}}'


### PR DESCRIPTION
Workflow `Release` теперь для тега `v*`: 
- либо создаёт релиз с результатом сборки  при пуше тега
- либо добавляет результат сборки в релиз, созданный через web-интерфейс/`gh`