### PR TITLE
Исправление ошибок с экранированием в курсе LFD113x

### DIFF
--- a/LFD113x-RU/Chapters/Chapter2.adoc
+++ b/LFD113x-RU/Chapters/Chapter2.adoc
@@ -292,7 +292,7 @@ gcc -O3 -fauto-profile=a.gcov test.c -o b.out
 
 [source,bash]
 ----
-size gcc/11/libstdc{pp}.dylib
+size gcc/11/libstdc++.dylib
 ----
 
 [source,bash]
@@ -307,7 +307,7 @@ __TEXT    __DATA    __OBJC    others    dec    hex
 
 [source,bash]
 ----
-strings gcc/11/libstdc{pp}.dylib | wc -l
+strings gcc/11/libstdc++.dylib | wc -l
 ----
 
 [source,bash]
@@ -322,7 +322,7 @@ strings gcc/11/libstdc{pp}.dylib | wc -l
 
 [source,bash]
 ----
-bloaty gcc/11/libstdc{pp}.dylib
+bloaty gcc/11/libstdc++.dylib
 ----
 
 [source,bash]

--- a/LFD113x-RU/Chapters/Chapter3.adoc
+++ b/LFD113x-RU/Chapters/Chapter3.adoc
@@ -129,9 +129,9 @@ https://github.com/riscv-software-src/riscv-isa-sim#compiling-and-running-a-simp
 поэтому для начала рекомендуется использовать Linux-машину.
 . набор инструментов
 RISC-V: https://github.com/riscv-software-src
-. QEMU: `git clone --depth 1 --branch v5.0.0 https://github.com/qemu/qemu`
-. Linux: `git clone --depth 1 --branch v5.4 https://github.com/torvalds/linux`
-. Busybox: `git clone --depth 1 git://git.busybox.net/busybox`
+. QEMU: `+git clone --depth 1 --branch v5.0.0 https://github.com/qemu/qemu+`
+. Linux: `+git clone --depth 1 --branch v5.4 https://github.com/torvalds/linux+`
+. Busybox: `+git clone --depth 1 git://git.busybox.net/busybox+`
 
 Перечисленные выше ветки репозиториев являются предлагаемыми версиями, которые могут часто меняться.
 Вы можете выбрать и другие.


### PR DESCRIPTION
- В главе 2: в блоке с исходным кодом не надо использовать макрос `{pp}` (он не раскрывается)
- В главе 3: в командах со ссылками ссылки экранированы для визуального единообразия

